### PR TITLE
Broken code warning: SimpleLoader conflicting TaskHandler implementation

### DIFF
--- a/channel-loader/src/diesel.rs
+++ b/channel-loader/src/diesel.rs
@@ -2,4 +2,4 @@ mod error;
 mod loader;
 
 pub use error::{DieselError, SimpleDieselError};
-pub use loader::DieselLoader;
+pub use loader::{DieselLoader, NotDieselLoader};

--- a/channel-loader/src/diesel/loader.rs
+++ b/channel-loader/src/diesel/loader.rs
@@ -8,6 +8,9 @@ use tokio::task::spawn_blocking;
 
 use super::error::{DieselError, SimpleDieselError};
 
+pub auto trait NotDieselLoader {}
+impl<T> !NotDieselLoader for T where T: DieselLoader {}
+
 /// a [`diesel`] specific loader interface designed with that optimizes batching around connection acquisition using [`diesel_connection::get_connection`].
 pub trait DieselLoader: Send + Sync {
   type Key: Key;

--- a/channel-loader/src/lib.rs
+++ b/channel-loader/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(auto_traits)]
+#![feature(negative_impls)]
 #![allow(dead_code)]
 #[allow(rustdoc::private_intra_doc_links)]
 #[doc(hidden)]


### PR DESCRIPTION
```
error[E0119]: conflicting implementations of trait `task::TaskHandler`
  --> channel-loader/src/simple_loader.rs:19:1
   |
19 |  / impl<T> TaskHandler for T
20 |  | where
21 |  |   T: Default + SimpleLoader + NotDieselLoader + 'static,
22 |  | {
...   |
37 |  |   }
38 |  | }
   |  |_^ conflicting implementation
   | 
  ::: channel-loader/src/diesel/loader.rs:26:1
   |
26 | /  impl<T> TaskHandler for T
27 | |  where
28 | |    T: Default + DieselLoader + 'static,
29 | |  {
...  |
53 | |    }
54 | |  }
   | |__- first implementation here
```